### PR TITLE
Always override

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,6 +102,11 @@ runs:
     - run: rustup default ${{steps.parse.outputs.toolchain}}
       shell: bash
 
+    # set an override. whatever toolchain we resolved to above is the one we want ot ensure we use
+    # without this the toolchain file will always take precedence
+    - run: rustup override set ${{steps.parse.outputs.toolchain}}
+      shell: bash
+
     - id: rustc-version
       run: |
         : create cachekey


### PR DESCRIPTION
Default to always setting an override. This way whatever we evaluated our `toolchain` to (either passed in, set from the toolchain file, or defaulted) will be set to the toolchain used. This prevents a toolchain file from being used even when an input was explicitly set.