### PR TITLE
Remove using rev to set rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         id: toolchain
       - name: echo ${{'${{steps.toolchain.outputs.cachekey}}'}}
         run: echo '${{steps.toolchain.outputs.cachekey}}'
-      - run: |
+      - name: Confirm version matches toolchain file
+        run: |
+          set -x
           pip3 install yq
           if ! [[ $(rustc --version) =~ "$(tomlq -r '.toolchain.channel | select(. != null)' rust-toolchain.toml)" ]]; then
             echo "Version in rust-toolchain.toml is not in use."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
       - name: echo ${{'${{steps.toolchain.outputs.cachekey}}'}}
         run: echo '${{steps.toolchain.outputs.cachekey}}'
       - run: |
-          if ! [[ $(rustc --version) =~ "1.64.0" ]]; then
+          pip3 install yq
+          if ! [[ $(rustc --version) =~ "$(tomlq -r '.toolchain.channel | select(. != null)' rust-toolchain.toml)" ]]; then
             echo "Version in rust-toolchain.toml is not in use."
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -15,19 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: IronCoreLabs/rust-toolchain@stable
+      - uses: IronCoreLabs/rust-toolchain@v1
       - run: cargo test --all-features
 ```
-
-The selection of Rust toolchain is made based on the particular @rev of this
-Action being requested. For example "IronCoreLabs/rust-toolchain@nightly" pulls in
-the nightly Rust toolchain, while "IronCoreLabs/rust-toolchain@1.42.0" pulls in
-1.42.0.
 
 ## Toolchain File
 
 The [Rust toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) is supported.
-If present it will be used to populate `toolchain`, `components` and `targets` parameters. If those parameters are explicitly set as inputs to the action, they will take precedence over the values in the toolchain file. To use only the toolchain file for parameters, pass no inputs and set the @rev to @main.
+If present it will be used to populate `toolchain`, `components` and `targets` parameters. If those parameters are explicitly set as inputs to the action, they will take precedence over the values in the toolchain file. To use only the toolchain file for parameters, pass no inputs and set the `@rev` to `@v1`.
 
 ## Inputs
 
@@ -41,9 +36,7 @@ All inputs are optional.
 <tr>
   <td><code>toolchain</code></td>
   <td>
-    Rustup toolchain specifier e.g. <code>stable</code>, <code>nightly</code>, <code>1.42.0</code>, <code>nightly-2022-01-01</code>.
-    <b>Important: the default is to match the @rev as described above.</b>
-    When passing an explicit <code>toolchain</code> as an input instead of @rev, you'll want to use "IronCoreLabs/rust-toolchain@main" as the revision of the action.
+    Rustup toolchain specifier e.g. <code>stable</code>, <code>nightly</code>, <code>1.42.0</code>, <code>nightly-2022-01-01</code>. Defaults to <code>stable</code> if not passed or in the <code>rust-toolchain.toml</code>.
   </td>
 </tr>
 <tr>
@@ -83,7 +76,7 @@ compiler support.
 ```yaml
      # Installs the most recent stable toolchain as of the specified time
      # offset, which may be written in years, months, weeks, or days.
-  - uses: IronCoreLabs/rust-toolchain@main
+  - uses: IronCoreLabs/rust-toolchain@v1
     with:
       toolchain: stable 18 months ago
 ```
@@ -91,7 +84,7 @@ compiler support.
 ```yaml
      # Installs the stable toolchain which preceded the most recent one by
      # the specified number of minor versions.
-  - uses: IronCoreLabs/rust-toolchain@main
+  - uses: IronCoreLabs/rust-toolchain@v1
     with:
       toolchain: stable minus 8 releases
 ```


### PR DESCRIPTION
We'll have a moving tag of `v1` until there's a breaking change.