### PR TITLE
Use the system `yq` now that it has toml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,6 @@ runs:
   steps:
     - id: extract-toml-values
       run: |
-        # once https://github.com/mikefarah/yq/pull/1439 is merged, the yq already on the system will have toml support
-        pip3 install yq
         for F in rust-toolchain.toml rust-toolchain ; do
           if [ -f "$F" ] ; then
             TOML_FILE="$F"


### PR DESCRIPTION
System `yq` now has toml support, so we can dodge this issue.

https://github.com/IronCoreLabs/rust-tool-cache/actions/runs/8510294473